### PR TITLE
Update dependencies.kt med nyeste teamdokumenthandtering-avro-schemas

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -10,7 +10,7 @@ object Avro: DependencyGroup {
 
 object Doknotifikasjon: DependencyGroup {
     override val groupId get() = "no.nav.teamdokumenthandtering"
-    override val version get() = "08c0b2d2"
+    override val version get() = "1.1.6"
 
     val schemas get() = dependency("teamdokumenthandtering-avro-schemas")
 }


### PR DESCRIPTION
Hei! 
Dere bruker en gammel versjon av teamdokumenthandtering-avro-schemas. Vi brukte tidligere git short hash til å identifisere versjon, men dette skaper krøll for Dependabot som ikke forstår hva som er nyeste versjon. Vi har gått over til semver og vil at dere oppdaterer slik at vi kan slette de gamle releasene og Dependabot foreslår riktig versjon for oppdateringer.
Kan dere sjekke at oppdatering til siste versjon av teamdokumenthandtering-avro-schemas går fint og ta det i bruk?